### PR TITLE
Execute kwargs

### DIFF
--- a/tinyquery/api_client.py
+++ b/tinyquery/api_client.py
@@ -36,7 +36,9 @@ class FakeHttpRequest(object):
         self.args = args
         self.kwargs = kwargs
 
-    def execute(self, **kwargs):
+    def execute(self, http=None, num_retries=0):
+        # It probably doesn't make sense to support http or num_retries in
+        # a mock, but we need to accept them as kwargs to avoid errors
         return self.func(*self.args, **self.kwargs)
 
 

--- a/tinyquery/api_client.py
+++ b/tinyquery/api_client.py
@@ -36,7 +36,7 @@ class FakeHttpRequest(object):
         self.args = args
         self.kwargs = kwargs
 
-    def execute(self):
+    def execute(self, **kwargs):
         return self.func(*self.args, **self.kwargs)
 
 


### PR DESCRIPTION
The bigquery client we're using passes args to the execute function - this just ignores them but at least it doesn't error!